### PR TITLE
Adding timeouts while updating,deleting or creating proxy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -86,6 +86,8 @@ module "rds_proxy" {
   max_idle_connections_percent = var.max_idle_connections_percent
   session_pinning_filters      = var.session_pinning_filters
   existing_iam_role_arn        = var.existing_iam_role_arn
-
+  proxy_create_timeout         = var.proxy_create_timeout
+  proxy_update_timeout         = var.proxy_update_timeout
+  proxy_delete_timeout         = var.proxy_delete_timeout
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -155,3 +155,20 @@ variable "existing_iam_role_arn" {
   default     = null
   description = "The ARN of an existing IAM role that the proxy can use to access secrets in AWS Secrets Manager. If not provided, the module will create a role to access secrets in Secrets Manager"
 }
+
+variable "proxy_create_timeout" {
+  type        = string
+  default     = "30m"
+  description = "Issues a timeout while proxy creation when specified value is reached"
+}
+
+variable "proxy_update_timeout" {
+  type        = string
+  default     = "30m"
+  description = "Issues a timeout while updating proxy when specified value is reached"
+}
+variable "proxy_delete_timeout" {
+  type        = string
+  default     = "60m"
+  description = "Issues a timeout while deleting proxy when specified value is reached"
+}

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,11 @@ resource "aws_db_proxy" "this" {
   }
 
   tags = module.this.tags
+  timeouts {
+    create = var.proxy_create_timeout
+    update = var.proxy_update_timeout
+    delete = var.proxy_delete_timeout
+  }
 }
 
 resource "aws_db_proxy_default_target_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,20 @@ variable "kms_key_id" {
   default     = null
   description = "The ARN or Id of the AWS KMS customer master key (CMK) to encrypt the secret values in the versions stored in secrets. If you don't specify this value, then Secrets Manager defaults to using the AWS account's default CMK (the one named `aws/secretsmanager`)"
 }
+
+variable "proxy_create_timeout" {
+  type        = string
+  default     = "30m"
+  description = "Issues a timeout while proxy creation when specified value is reached"
+}
+
+variable "proxy_update_timeout" {
+  type        = string
+  default     = "30m"
+  description = "Issues a timeout while updating proxy when specified value is reached"
+}
+variable "proxy_delete_timeout" {
+  type        = string
+  default     = "60m"
+  description = "Issues a timeout while deleting proxy when specified value is reached"
+}


### PR DESCRIPTION
## what
* Currently, proxy deletion timeouts after 60m. This change will let the user specify proxy deletion should the timeout be more than 60m. We have seen this as the constant pain point during our terratests which spin up & delete proxies for tests run. 

## why
* We have seen deletion of the RDS proxy that are spun for tests timing out when the proxy infra is destroyed. Tearing down proxy seems to me like a long aws workflow which, sometimes times out when 60m is hit causing our terratests to fail. 

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy#timeouts

