### PR TITLE
Convert auth variable input to set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_db_proxy" "this" {
   vpc_subnet_ids         = var.vpc_subnet_ids
 
   dynamic "auth" {
-    for_each = var.auth
+    for_each = toset(var.auth)
 
     content {
       auth_scheme = auth.value.auth_scheme


### PR DESCRIPTION
## what

This will prevent complete auth recreations if a given value changes index in the list.

## why
https://github.com/cloudposse/terraform-aws-rds-db-proxy/issues/12
Prevents unnecessary auth replacements

## references

Fixes https://github.com/cloudposse/terraform-aws-rds-db-proxy/issues/12
